### PR TITLE
refactor: traits are now bitshifted int

### DIFF
--- a/My project/Assets/Scripts/CreatureLogic/Actions/Food/FindFood.cs
+++ b/My project/Assets/Scripts/CreatureLogic/Actions/Food/FindFood.cs
@@ -32,14 +32,14 @@ public class FindFood : IAction
 
     public void AddTraits(TraitData traitData)
     {
-        switch (traitData.traits[Traits.FOOD][(int)FoodTraits.DIET])
+        switch (traitData.traits[Traits.FOOD][FoodTraits.DIET])
         {
-            case (int)FoodDiet.HERBIVORE:
-                //Debug.Log("Herbivore : " + traitData.traits[Traits.FOOD][(int)FoodTraits.DIET]);
+            case FoodTraits.DIET_HERBIVORE & (int) Traits.SUBMASK:
+                Debug.Log("Herbivore : " + traitData.traits[Traits.FOOD][(int)FoodTraits.DIET]);
                 findFoodStrategy = new FindFoodHerbivore();
                 break;
             default:
-                //Debug.Log("Omnivore : " + traitData.traits[Traits.FOOD][(int)FoodTraits.DIET]);
+                Debug.Log("Omnivore : " + traitData.traits[Traits.FOOD][(int)FoodTraits.DIET]);
                 findFoodStrategy = new FindFoodOmnivore();
                 break;
         }

--- a/My project/Assets/Scripts/CreatureLogic/Actions/sleeping/Sleeping.cs
+++ b/My project/Assets/Scripts/CreatureLogic/Actions/sleeping/Sleeping.cs
@@ -19,12 +19,12 @@ public class Sleeping : IAction
 
     public void AddTraits(TraitData traitData)
     {
-        switch (traitData.traits[Traits.SLEEPING][(int)SleepTraits.SLEEPPATTERN])
+        switch (traitData.traits[Traits.SLEEPING][SleepTraits.SLEEPPATTERN])
         {
-            case (int)SleepPattern.DAY:
+            case SleepTraits.SLEEPPATTERN_DAY & (int)Traits.SUBMASK:
                 sleepDuration = TimeManager.Instance.secondsPerDay;
                 break;
-            case (int)SleepPattern.NIGHT:
+            case SleepTraits.SLEEPPATTERN_NIGHT & (int)Traits.SUBMASK:
                 sleepDuration = TimeManager.Instance.secondsPerDay - TimeManager.Instance.daytimeSeconds;
                 break;
         }

--- a/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/FoodTraits.cs
+++ b/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/FoodTraits.cs
@@ -2,21 +2,16 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public enum FoodTraits : int
+public static class FoodTraits
 {
-    DIET,
-    RESISTANCES,
-}
+    public const int DIET = 0;
+    public const int NUMDIET = 3;
+    public const int DIET_CARNIVORE = 0 << 8;
+    public const int DIET_HERBIVORE = 1 << 8;
+    public const int DIET_OMNIVORE = 2 << 8;
 
-public enum FoodDiet : int
-{
-    CARNIVORE,
-    HERBIVORE,
-    OMNIVORE
-}
-
-public enum FoodResistances : int
-{
-    NONE,
-    POISONS
+    public const int RESISTANCES = 1;
+    public const int NUMRESISTANCES = 2;
+    public const int RESISTANCES_NONE = 0 << 8;
+    public const int RESISTANCES_POISONS = 1 << 8;
 }

--- a/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/MovementTraits.cs
+++ b/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/MovementTraits.cs
@@ -2,13 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public enum MovementTraits
-{
-    WATER
-}
-
-public enum WaterMovement
-{
-    CANSWIM,
-    LANDONLY
-}
+public static class MovementTraits{
+    public const int WATER = 0;
+    public const int NUMWATER = 2;
+    public const int WATER_CANSWIM = 0 << 8;
+    public const int WATER_LANDONLY = 1 << 8;
+}   

--- a/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/SleepTraits.cs
+++ b/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/SleepTraits.cs
@@ -2,13 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public enum SleepTraits
+public static class SleepTraits
 {
-    SLEEPPATTERN
-}
-
-public enum SleepPattern
-{
-    NIGHT,
-    DAY
+    public const int SLEEPPATTERN = 0;
+    public const int NUMSLEEPPATTERN = 2;
+    public const int SLEEPPATTERN_NIGHT = 0 << 8;
+    public const int SLEEPPATTERN_DAY = 21<< 8;
 }

--- a/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/TraitBuilder.cs
+++ b/My project/Assets/Scripts/CreatureLogic/CreatureData/Traits/TraitBuilder.cs
@@ -19,29 +19,24 @@ public class TraitBuilder
 
     public TraitBuilder BuildMovementTraits()
     {
-        Dictionary<int, int> movementTraits = new();
-        //can swim made by some random 50%
-        movementTraits.Add((int)MovementTraits.WATER, Random.Range(0,Enum.GetNames(typeof(WaterMovement)).Length));
+        Dictionary<int,int > movementTraits = new();
+        movementTraits.Add(MovementTraits.WATER,RandomTrait(MovementTraits.NUMWATER));
         traits.Add(Traits.MOVEMENT, movementTraits);
         return this;
     }
 
     public TraitBuilder BuildSleepingTraits()
     {
-        //sleeping pattern
-        //random choice between night or day
         Dictionary<int, int> sleepingTraits = new();
-        sleepingTraits.Add((int) SleepTraits.SLEEPPATTERN, Random.Range(0,Enum.GetNames(typeof(SleepPattern)).Length));
+        sleepingTraits.Add(SleepTraits.SLEEPPATTERN, RandomTrait(SleepTraits.NUMSLEEPPATTERN));
         traits.Add(Traits.SLEEPING, sleepingTraits);
         return this;
     }
 
     public TraitBuilder BuildFoodTraits()
     {
-        //diet
-        //random choice between veggies or both
         Dictionary<int, int> foodTraits = new();
-        foodTraits.Add((int)FoodTraits.DIET, Random.Range(0, Enum.GetNames(typeof(FoodDiet)).Length));
+        foodTraits.Add(FoodTraits.DIET, RandomTrait(FoodTraits.NUMDIET));
         traits.Add(Traits.FOOD, foodTraits);
         return this;
     }
@@ -50,10 +45,16 @@ public class TraitBuilder
     {
         return traits;
     }
+
+    public static int RandomTrait(int range)
+    {
+        return Random.Range(0, range) << 8;
+    }
 }
 
 public enum Traits
 {
+    SUBMASK = 0xFF00,
     MOVEMENT,
     FOOD,
     SLEEPING


### PR DESCRIPTION
### context
I wanted weight and traits to be contained in the same variable, so by having all traits adhere to 0xFF00 for the trait, and 0x00FF for the weight for passing it down

### update
- All trait classes are now static classes instead of enums
- The option of the specified traits are now stored as bit shifted int
- This will allowed for ease of coding for weighting the traits when passing them on

### testing
Debug.log to ensure correct options are being delivered